### PR TITLE
Use Python logo for opshin

### DIFF
--- a/kits/opshin-starter-kit/metadata.yaml
+++ b/kits/opshin-starter-kit/metadata.yaml
@@ -1,5 +1,5 @@
 title: OpShin Starter Kit
-logo: https://raw.githubusercontent.com/OpShin/opshin/master/opshin.png
+logo: https://demeter.run/assets/logos/python.png
 description: A starter kit for python based smart contracts with PyCardano and OpShin
 repository: https://github.com/opshin/opshin-starter-kit.git
 features:


### PR DESCRIPTION
For the sake of recognizability, the starter kit for opshin smart contracts should have the python logo and not the opshin logo.